### PR TITLE
Moment-timezone dependency fix and comparison typing bug fix

### DIFF
--- a/src/client/app/incidents/chart/chart.component.ts
+++ b/src/client/app/incidents/chart/chart.component.ts
@@ -146,7 +146,7 @@ export class IncidentsChartComponent implements OnInit, OnChanges {
     });
 
     this.yAxis
-      .ticks(yMax > 5 ? 5 : yMax)
+      .ticks(Number(yMax) > 5 ? 5 : yMax)
       .tickSize(-this.width);
 
     this.svg.selectAll('*').remove();

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -37,7 +37,7 @@ export class ProjectConfig extends SeedConfig {
       {src: 'normalize.css/normalize.css', inject: true},
       {src: 'leaflet/dist/leaflet.css', inject: true},
       {src: 'moment/moment.js', inject: 'libs'},
-      {src: 'moment-timezone/builds/moment-timezone-with-data-2010-2020.js', inject: 'libs'},
+      {src: 'moment-timezone/builds/moment-timezone-with-data-2012-2022.js', inject: 'libs'},
       {src: 'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js', inject: 'libs'},
       {src: 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css', inject: true}
     ];
@@ -60,7 +60,7 @@ export class ProjectConfig extends SeedConfig {
       'd3': 'node_modules/d3/build/d3.min.js',
       'd3-tip': 'node_modules/d3-tip/index.js',
       'moment': 'node_modules/moment/moment.js',
-      'moment-timezone': 'node_modules/moment-timezone/builds/moment-timezone-with-data-2010-2020.js'
+      'moment-timezone': 'node_modules/moment-timezone/builds/moment-timezone-with-data-2012-2022.js'
     });
     this.mergeObject(this.SYSTEM_BUILDER_CONFIG['packages'], {
       'angular2-cookie': {
@@ -72,7 +72,7 @@ export class ProjectConfig extends SeedConfig {
         defaultExtension: 'js'
       },
       'moment-timezone': {
-        main: 'builds/moment-timezone-with-data-2010-2020.min.js',
+        main: 'builds/moment-timezone-with-data-2012-2022.min.js',
         defaultExtension: 'js'
       }
     });


### PR DESCRIPTION
When forking and attempting to run the app, I ran into two very minor issues.

1. Moment-timezone dependency (moment-timezone-with-data-20**-20**.js).
- The date ranges of the data file changed due to a new release of moment-timezone. This wouldn't be immediately obvious until purging and re-installing this dependency.
- Is getting the latest version of this package essential? If not, you could remove the carrot from package.json and avoid the issue going forward, manually updating it in the future.

2. A string vs. number comparison was causing a compilation error. I added a line to convert the string to a number, which it was being used as. 